### PR TITLE
adjusted NEWS to reflect bug correction in phylo.pls for v2.1.3

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -32,7 +32,7 @@ CHANGES IN GEOMORPH VERSION 2.1.3
   BUG FIXES
 
     o Corrected error printing output of ANOVA table of bilat.symmetry()
-
+    o Corrected error in phylo.pls code that generated erroneous P values
 
 CHANGES IN GEOMORPH VERSION 2.1.2
 


### PR DESCRIPTION
The code for phylo.pls in v2.1.1 had a duplicated section of permutation tests that led to unreliable significance tests. By the time v2.1.3 came out this section was removed. I just updated the NEWS to point out that this update occurred. I ran into this today and I went down the rabbit hole figuring out why I started getting different P values from this function after switching from v2.1.1 to v2.1.3.